### PR TITLE
chore: use entire history in checkout for bump_version

### DIFF
--- a/.github/workflows/bump_version.yaml
+++ b/.github/workflows/bump_version.yaml
@@ -8,6 +8,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
+        # Make sure entire history is checked out.
+        with:
+          fetch-depth: 0
       - name: Bump version and push tag
         uses: mathieudutour/github-tag-action@v4.2
         with:


### PR DESCRIPTION
Fix bumping version