### PR TITLE
refactor: removes useless checks of satellite_occupation

### DIFF
--- a/src/halomod/halo_model.py
+++ b/src/halomod/halo_model.py
@@ -1104,17 +1104,14 @@ class TracerHaloModel(DMHaloModel):
 
         Note: this may not exist for every kind of tracer.
         """
-        if hasattr(self.hod, "satellite_occupation"):
-            # Integrand is just the density of satellite galaxies at mass m
-            integrand = (
-                self.m[self._tm]
-                * self.dndm[self._tm]
-                * self.hod.satellite_occupation(self.m[self._tm])
-            )
-            s = intg.trapz(integrand, dx=np.log(self.m[1] / self.m[0]))
-            return s / self.mean_tracer_den
-        else:
-            raise AttributeError("This HOD has no concept of a satellite")
+        # Integrand is just the density of satellite galaxies at mass m
+        integrand = (
+            self.m[self._tm]
+            * self.dndm[self._tm]
+            * self.hod.satellite_occupation(self.m[self._tm])
+        )
+        s = intg.trapz(integrand, dx=np.log(self.m[1] / self.m[0]))
+        return s / self.mean_tracer_den
 
     @cached_quantity
     def central_fraction(self):
@@ -1164,9 +1161,6 @@ class TracerHaloModel(DMHaloModel):
 
         Note: May not exist for every kind of tracer.
         """
-        if not hasattr(self.hod, "ss_pairs"):
-            raise AttributeError("The HOD being used has no satellite occupation")
-
         u = self.tracer_profile_ukm[:, self._tm]
         integ = (
             u ** 2
@@ -1210,8 +1204,6 @@ class TracerHaloModel(DMHaloModel):
 
         Note: May not exist for every kind of tracer.
         """
-        if not hasattr(self.hod, "ss_pairs"):
-            raise AttributeError("The HOD being used has no satellite occupation")
 
         if self.tracer_profile.has_lam:
             lam = self.tracer_profile_lam
@@ -1250,9 +1242,6 @@ class TracerHaloModel(DMHaloModel):
 
         Note: May not exist for every kind of tracer.
         """
-        if not hasattr(self.hod, "cs_pairs"):
-            raise AttributeError("The HOD being used has no satellite occupation")
-
         u = self.tracer_profile_ukm[:, self._tm]
         integ = (
             self.dndm[self._tm]
@@ -1295,9 +1284,6 @@ class TracerHaloModel(DMHaloModel):
 
         Note: May not exist for every kind of tracer.
         """
-        if not hasattr(self.hod, "cs_pairs"):
-            raise AttributeError("The HOD being used has no satellite occupation")
-
         rho = self.tracer_profile_rho[:, self._tm]
         integ = (
             self.dndm[self._tm]

--- a/tests/test_bias.py
+++ b/tests/test_bias.py
@@ -11,7 +11,7 @@ from halomod import DMHaloModel
 @pytest.fixture(scope="module")
 def hmf():
     """Simple hmf object that gives us reasonable defaults for the bias."""
-    return MassFunction()
+    return MassFunction(transfer_model="EH")
 
 
 @pytest.mark.parametrize("bias_model", list(bias.Bias._models.values()))

--- a/tests/test_concentration.py
+++ b/tests/test_concentration.py
@@ -20,7 +20,7 @@ def test_duffy(mass, mdef):
 
 def test_ludlow_vs_colossus():
     """Test the Ludlow relation between native and colossus implementations."""
-    mf = MassFunction()
+    mf = MassFunction(transfer_model="EH")
 
     L16Colossus = cm.make_colossus_cm(model="ludlow16")
 

--- a/tests/test_halo_model.py
+++ b/tests/test_halo_model.py
@@ -20,12 +20,12 @@ def test_default_actually_inits(model):
 
 @pytest.fixture(scope="module")
 def dmhm():
-    return DMHaloModel()
+    return DMHaloModel(transfer_model="EH")
 
 
 @pytest.fixture(scope="module")
 def thm():
-    return TracerHaloModel(rmin=0.01, rmax=50, rnum=20)
+    return TracerHaloModel(rmin=0.01, rmax=50, rnum=20, transfer_model="EH")
 
 
 def test_dm_model_instances(dmhm):
@@ -77,6 +77,7 @@ def test_setting_default_tracers_conc():
         halo_concentration_model="Ludlow16",
         tracer_concentration_model="Duffy08",
         halo_concentration_params={"f": 0.02, "C": 650,},
+        transfer_model="EH",
     )
 
     assert hm.tracer_concentration.params == hm.tracer_concentration._defaults
@@ -90,6 +91,7 @@ def test_setting_default_tracers_prof():
         halo_concentration_model="Ludlow16",
         tracer_concentration_model="Duffy08",
         halo_profile_params={"alpha": 1.1},
+        transfer_model="EH",
     )
 
     assert hm.tracer_profile.params == hm.tracer_profile._defaults

--- a/tests/test_wdm.py
+++ b/tests/test_wdm.py
@@ -13,6 +13,7 @@ def test_cmz_wdm():
         halo_concentration_model="Duffy08WDM",
         wdm_mass=3.3,
         Mmin=7.0,
+        transfer_model="EH",
     )
     cdm = DMHaloModel(
         hmf_model="SMT",
@@ -22,6 +23,7 @@ def test_cmz_wdm():
         filter_params={"c": 2.5},
         halo_concentration_model="Duffy08",
         Mmin=7.0,
+        transfer_model="EH",
     )
 
     assert np.all(
@@ -41,6 +43,7 @@ def test_ludlow_cmz_wdm():
         halo_profile_model="Einasto",
         wdm_mass=3.3,
         Mmin=7.0,
+        transfer_model="EH",
     )
     cdm = DMHaloModel(
         hmf_model="SMT",
@@ -51,6 +54,7 @@ def test_ludlow_cmz_wdm():
         halo_profile_model="Einasto",
         Mmin=7.0,
         mdef_model="SOCritical",
+        transfer_model="EH",
     )
 
     assert np.all(


### PR DESCRIPTION
Removes checking of whether `satellite_occupation` exists on HOD objects, since it always exists.
Also improves some test performance.

Fixes #52