### PR TITLE
fix: ensure model params are always dicts

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -33,6 +33,7 @@ Bugfixes
 * Fix for when no tracer profile/concentration params are given. Now use the halo params
   iff the tracer model is equal to the halo one.
 * Fix for halo profile numerical FT.
+* Fix #59 -- can't have non-dict ``model_params``.
 
 v1.4.5
 ------

--- a/src/halomod/halo_model.py
+++ b/src/halomod/halo_model.py
@@ -978,7 +978,7 @@ class TracerHaloModel(DMHaloModel):
             ):
                 tr_params = self.halo_profile_params
             else:
-                tr_params = {}
+                tr_params = self.tracer_profile_params
 
             this_profile = self.tracer_profile_model(
                 cm_relation=None, mdef=self.mdef, z=self.z, **tr_params,
@@ -986,11 +986,11 @@ class TracerHaloModel(DMHaloModel):
 
         if (
             not self.tracer_concentration_params
-            and self.tracer_profile_model == self.halo_profile_model
+            and self.tracer_concentration_model == self.halo_concentration_model
         ):
-            tr_params = self.halo_profile_params
+            tr_params = self.halo_concentration_params
         else:
-            tr_params = {}
+            tr_params = self.tracer_concentration_params
 
         return self.tracer_concentration_model(
             cosmo=Cosmology(self.cosmo),
@@ -1019,7 +1019,7 @@ class TracerHaloModel(DMHaloModel):
         ):
             tr_params = self.halo_profile_params
         else:
-            tr_params = {}
+            tr_params = self.tracer_profile_params
 
         return self.tracer_profile_model(
             cm_relation=self.tracer_concentration,

--- a/src/halomod/halo_model.py
+++ b/src/halomod/halo_model.py
@@ -877,6 +877,8 @@ class TracerHaloModel(DMHaloModel):
     def tracer_profile_params(self, val: dict):
         """Dictionary of parameters for the tracer Profile model."""
         assert val is None or isinstance(val, dict)
+        if val is None:
+            val = {}
         return val
 
     @parameter("model")
@@ -911,6 +913,8 @@ class TracerHaloModel(DMHaloModel):
     def tracer_concentration_params(self, val):
         """Dictionary of parameters for tracer concentration-mass relation."""
         assert val is None or isinstance(val, dict)
+        if val is None:
+            val = {}
         return val
 
     @parameter("switch")
@@ -967,21 +971,26 @@ class TracerHaloModel(DMHaloModel):
             # Need to get the tracer profile params if it wasn't given.
             # If we have the same tracer and halo profiles, use the halo profile
             # params. Otherwise, don't give any params.
-            if self.tracer_profile_params is None:
-                if self.tracer_profile_model == self.halo_profile_model:
-                    tr_params = self.halo_profile_params
-                else:
-                    tr_params = {}
+            # Note that tracer_profile_params *always* has to be a dict.
+            if (
+                not self.tracer_profile_params
+                and self.tracer_profile_model == self.halo_profile_model
+            ):
+                tr_params = self.halo_profile_params
+            else:
+                tr_params = {}
 
             this_profile = self.tracer_profile_model(
                 cm_relation=None, mdef=self.mdef, z=self.z, **tr_params,
             )
 
-        if self.tracer_concentration_params is None:
-            if self.tracer_profile_model == self.halo_profile_model:
-                tr_params = self.halo_profile_params
-            else:
-                tr_params = {}
+        if (
+            not self.tracer_concentration_params
+            and self.tracer_profile_model == self.halo_profile_model
+        ):
+            tr_params = self.halo_profile_params
+        else:
+            tr_params = {}
 
         return self.tracer_concentration_model(
             cosmo=Cosmology(self.cosmo),
@@ -1004,11 +1013,13 @@ class TracerHaloModel(DMHaloModel):
         if self.tracer_profile_model is None:
             return self.halo_profile
 
-        if self.tracer_profile_params is None:
-            if self.tracer_profile_model == self.halo_profile_model:
-                tr_params = self.halo_profile_params
-            else:
-                tr_params = {}
+        if (
+            not self.tracer_profile_params
+            and self.tracer_profile_model == self.halo_profile_model
+        ):
+            tr_params = self.halo_profile_params
+        else:
+            tr_params = {}
 
         return self.tracer_profile_model(
             cm_relation=self.tracer_concentration,

--- a/tests/test_halo_model.py
+++ b/tests/test_halo_model.py
@@ -89,6 +89,21 @@ def test_setting_default_tracers_conc():
     assert hm.tracer_concentration.params == hm.tracer_concentration._defaults
 
 
+def test_setting_default_tracers_conc_set_params():
+    """Tests setting default tracer parameters based on halo parameters"""
+    hm = TracerHaloModel(
+        halo_profile_model="NFW",
+        tracer_profile_model="NFW",
+        halo_concentration_model="Ludlow16",
+        tracer_concentration_model="Ludlow16",
+        tracer_concentration_params={"f": 0.03, "C": 657,},
+        transfer_model="EH",
+    )
+
+    assert hm.tracer_concentration.params["f"] == 0.03
+    assert hm.tracer_concentration.params["C"] == 657
+
+
 def test_setting_default_tracers_prof():
     """Tests setting default tracer parameters based on halo parameters"""
     hm = TracerHaloModel(
@@ -109,7 +124,6 @@ def test_setting_default_tracers_same_model():
         tracer_profile_model="NFW",
         halo_concentration_model="Ludlow16",
         tracer_concentration_model="Ludlow16",
-        #        halo_profile_params={"alpha": 1.1},
         transfer_model="EH",
     )
 

--- a/tests/test_halo_model.py
+++ b/tests/test_halo_model.py
@@ -103,6 +103,20 @@ def test_setting_default_tracers_prof():
     assert hm.tracer_profile.params == hm.tracer_profile._defaults
 
 
+def test_setting_default_tracers_same_model():
+    hm = TracerHaloModel(
+        halo_profile_model="NFW",
+        tracer_profile_model="NFW",
+        halo_concentration_model="Ludlow16",
+        tracer_concentration_model="Ludlow16",
+        #        halo_profile_params={"alpha": 1.1},
+        transfer_model="EH",
+    )
+
+    assert hm.tracer_profile.params == hm.halo_profile.params
+    assert hm.halo_concentration.params == hm.tracer_concentration.params
+
+
 @pytest.mark.parametrize(
     "dep,new",
     [


### PR DESCRIPTION
<!--
Thank you for creating a PR on hmf!

Please read through the following and check the boxes to ensure
your PR meets our coding standards and that it follows the
correct pathways for testing and deployment.
-->

# Description
<!-- Write a brief description of what the new feature does, and how a review could take it for a spin -->
Any parameters that are `model_params` must always be dictionary (though they can be empty).

# Issues
<!-- If this feature is in response to any open issues, reference them here by adding a line for each, with "Fixes #xx".
     Otherwise remove this section.
-->
Fixes #59
Fixes #68 




